### PR TITLE
Added missing / in README example

### DIFF
--- a/README.md
+++ b/README.md
@@ -117,7 +117,7 @@ const YourComponent = () => (
     </ConnectivityRenderer>
     <View>
       <Text>Another Section</Text>
-    <View>
+    </View>
     <ConnectivityRenderer>
       {isConnected => (
         <SnackBar


### PR DESCRIPTION
In a usage example, there was a missing / in View closing tag
I've put it back where it belongs! ;)

Have a nice day!