### PR TITLE
Creating sagas for handling connectivity changes

### DIFF
--- a/package.json
+++ b/package.json
@@ -58,6 +58,7 @@
     "react-native": "0.44.2",
     "redux": "^3.6.0",
     "redux-mock-store": "^1.2.2",
+    "redux-saga": "^0.15.6",
     "redux-thunk": "^2.2.0"
   },
   "dependencies": {

--- a/src/index.js
+++ b/src/index.js
@@ -15,9 +15,6 @@ module.exports = {
     return require('./actionTypes').default;
   },
   get networkEventsListenerSaga() {
-    return require('./saga').networkEventsListenerSaga;
-  },
-  get forceTryConnectivitySaga() {
-    return require('./saga').forceTryConnectivitySaga;
+    return require('./saga').default;
   },
 };

--- a/src/index.js
+++ b/src/index.js
@@ -14,4 +14,10 @@ module.exports = {
   get offlineActionTypes() {
     return require('./actionTypes').default;
   },
+  get networkEventsListenerSaga() {
+    return require('./saga').networkEventsListenerSaga;
+  },
+  get forceTryConnectivity() {
+    return require('./saga').forceTryConnectivity;
+  },
 };

--- a/src/index.js
+++ b/src/index.js
@@ -17,7 +17,7 @@ module.exports = {
   get networkEventsListenerSaga() {
     return require('./saga').networkEventsListenerSaga;
   },
-  get forceTryConnectivity() {
-    return require('./saga').forceTryConnectivity;
+  get forceTryConnectivitySaga() {
+    return require('./saga').forceTryConnectivitySaga;
   },
 };

--- a/src/saga.js
+++ b/src/saga.js
@@ -7,7 +7,7 @@ import checkInternetAccess from './checkInternetAccess';
 import { connectionChange } from './actionCreators';
 import type { NetworkState } from './types';
 
-export function* forceTryConnectivity(): Generator<*, *, *> {
+export function* forceTryConnectivitySaga(): Generator<*, *, *> {
   yield call(handleConnectivityChange, true);
 }
 
@@ -23,9 +23,7 @@ export function* networkEventsListenerSaga(
     }
   } finally {
     if (yield cancelled()) {
-      if (isConnectedChannel) {
-        isConnectedChannel.close();
-      }
+      isConnectedChannel.close();
     }
   }
 }
@@ -47,7 +45,7 @@ function* handleConnectivityChange(
   );
 
   if (hasInternetAccess && actionQueue.length > 0) {
-    for (const action of actionQueue) {
+    for (const action of actionQueue) { // eslint-disable-line
       yield put(action);
     }
   }
@@ -55,11 +53,10 @@ function* handleConnectivityChange(
 
 function createNetInfoIsConnectedChannel() {
   return eventChannel((emit: Function) => {
-    NetInfo.isConnected.addEventListener('change', emit);
+    NetInfo.isConnected.addEventListener('connectionChange', emit);
 
-    const removeEventListener = () => {
-      NetInfo.isConnected.removeEventListener('change', emit);
+    return () => {
+      NetInfo.isConnected.removeEventListener('connectionChange', emit);
     };
-    return removeEventListener;
   });
 }

--- a/src/saga.js
+++ b/src/saga.js
@@ -1,0 +1,65 @@
+/* @flow */
+
+import { put, select, call, take, cancelled, fork } from 'redux-saga/effects';
+import { eventChannel } from 'redux-saga';
+import { NetInfo } from 'react-native';
+import checkInternetAccess from './checkInternetAccess';
+import { connectionChange } from './actionCreators';
+import type { NetworkState } from './types';
+
+export function* forceTryConnectivity(): Generator<*, *, *> {
+  yield call(handleConnectivityChange, true);
+}
+
+export function* networkEventsListenerSaga(
+  timeout?: number,
+  pingServerUrl?: string,
+): Generator<*, *, *> {
+  const isConnectedChannel = yield call(createNetInfoIsConnectedChannel);
+  try {
+    while (true) {
+      const isConnected = yield take(isConnectedChannel);
+      yield fork(handleConnectivityChange, isConnected, timeout, pingServerUrl);
+    }
+  } finally {
+    if (yield cancelled()) {
+      if (isConnectedChannel) {
+        isConnectedChannel.close();
+      }
+    }
+  }
+}
+
+function* handleConnectivityChange(
+  isConnected: boolean,
+  timeout?: number,
+  pingServerUrl?: string,
+) {
+  const hasInternetAccess = yield call(
+    checkInternetAccess,
+    isConnected,
+    timeout,
+    pingServerUrl,
+  );
+  yield put(connectionChange(hasInternetAccess));
+  const actionQueue = select(
+    (state: { network: NetworkState }) => state.network.actionQueue,
+  );
+
+  if (hasInternetAccess && actionQueue.length > 0) {
+    for (const action of actionQueue) {
+      yield put(action);
+    }
+  }
+}
+
+function createNetInfoIsConnectedChannel() {
+  return eventChannel((emit: Function) => {
+    NetInfo.isConnected.addEventListener('change', emit);
+
+    const removeEventListener = () => {
+      NetInfo.isConnected.removeEventListener('change', emit);
+    };
+    return removeEventListener;
+  });
+}

--- a/yarn.lock
+++ b/yarn.lock
@@ -3972,6 +3972,10 @@ redux-mock-store@^1.2.2:
   version "1.2.3"
   resolved "https://registry.yarnpkg.com/redux-mock-store/-/redux-mock-store-1.2.3.tgz#1b3ad299da91cb41ba30d68e3b6f024475fb9e1b"
 
+redux-saga@^0.15.6:
+  version "0.15.6"
+  resolved "https://registry.yarnpkg.com/redux-saga/-/redux-saga-0.15.6.tgz#8638dc522de6c6c0a496fe8b2b5466287ac2dc4d"
+
 redux-thunk@^2.2.0:
   version "2.2.0"
   resolved "https://registry.yarnpkg.com/redux-thunk/-/redux-thunk-2.2.0.tgz#e615a16e16b47a19a515766133d1e3e99b7852e5"


### PR DESCRIPTION
This pull request introduces the functionality of the `withNetworkConnectivity` component wrapper inside a saga, so there's no need to wrap any components. The same functionality now can be achieved just by including a fork from the rootSaga as below:

```javascript
yield fork(networkEventsListenerSaga)
```

As pointed out on https://github.com/rauliyohmc/react-native-offline/issues/12, if you have multiple root components (eg. by using react-native-navigation), besides having to wrap all of them, you end up having HEAD requests for each wrapped component that is mounted, which I believe it's not ideal. This solves this issue.

Additionaly, there's a `forceTryConnectivity` saga, which forces the device to test the connectivity any time. This is very useful for the situation when there's network connectivity but no Internet access and the isConnected state is false. On this situation, if there's no connectivity change, the app will never know if Internet is accessible again, so for example, one could just check connectivity every time a request is intercepted as below:
```javascript
takeLatest(offlineActionTypes.FETCH_OFFLINE_MODE, forceTryConnectivity),
```
I believe using sagas could be a more elegant solution than wrapping components, although eslint does not agree. 