### PR TITLE
Use PropTypes from prop-types package instead of React.PropTypes

### DIFF
--- a/package.json
+++ b/package.json
@@ -53,6 +53,7 @@
     "husky": "^0.14.3",
     "jest": "^19.0.2",
     "prettier": "^1.3.1",
+    "prop-types": "^15.5.10",
     "react": "16.0.0-alpha.6",
     "react-native": "0.44.2",
     "redux": "^3.6.0",

--- a/src/ConnectivityRenderer.js
+++ b/src/ConnectivityRenderer.js
@@ -1,6 +1,7 @@
 /* @flow */
 
-import { Component, PropTypes } from 'react';
+import { Component } from 'react';
+import PropTypes from 'prop-types';
 import { NetInfo, Platform } from 'react-native';
 import checkInternetAccess from './checkInternetAccess';
 import reactConnectionStore from './reactConnectionStore';

--- a/src/withNetworkConnectivity.js
+++ b/src/withNetworkConnectivity.js
@@ -1,6 +1,7 @@
 /* @flow */
 
-import React, { Component, PropTypes } from 'react';
+import React, { Component } from 'react';
+import PropTypes from 'prop-types';
 import { NetInfo, Platform } from 'react-native';
 import hoistStatics from 'hoist-non-react-statics';
 import { connectionChange } from './actionCreators';

--- a/yarn.lock
+++ b/yarn.lock
@@ -3245,7 +3245,7 @@ longest@^1.0.1:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/longest/-/longest-1.0.1.tgz#30a0b2da38f73770e8294a0d22e6625ed77d0097"
 
-loose-envify@^1.0.0, loose-envify@^1.1.0:
+loose-envify@^1.0.0, loose-envify@^1.1.0, loose-envify@^1.3.1:
   version "1.3.1"
   resolved "https://registry.yarnpkg.com/loose-envify/-/loose-envify-1.3.1.tgz#d1a8ad33fa9ce0e713d65fdd0ac8b748d478c848"
   dependencies:
@@ -3721,6 +3721,13 @@ promise@^7.1.1:
   resolved "https://registry.yarnpkg.com/promise/-/promise-7.1.1.tgz#489654c692616b8aa55b0724fa809bb7db49c5bf"
   dependencies:
     asap "~2.0.3"
+
+prop-types@^15.5.10:
+  version "15.5.10"
+  resolved "https://registry.yarnpkg.com/prop-types/-/prop-types-15.5.10.tgz#2797dfc3126182e3a95e3dfbb2e893ddd7456154"
+  dependencies:
+    fbjs "^0.8.9"
+    loose-envify "^1.3.1"
 
 prr@~0.0.0:
   version "0.0.0"


### PR DESCRIPTION
Hello,
I recent versions of react, the PropTypes property was removed, and this module stopped working (I was interested in withNetworkConnectivity for example).
Would you mind releasing a version with this change which uses the external 'prop-types' package as source for PropTypes ?
