### PR TITLE
Makes configurable namespace for react-native-offline meta

### DIFF
--- a/src/createNetworkMiddleware.js
+++ b/src/createNetworkMiddleware.js
@@ -20,10 +20,15 @@ type State = {
 type Arguments = {|
   regexActionType: RegExp,
   actionTypes: Array<string>,
+  namespace?: string,
 |};
 
 function createNetworkMiddleware(
-  { regexActionType = /FETCH.*REQUEST/, actionTypes = [] }: Arguments = {},
+  {
+    regexActionType = /FETCH.*REQUEST/,
+    actionTypes = [],
+    namespace = '',
+  }: Arguments = {},
 ) {
   return ({ getState }: MiddlewareAPI<State>) => (
     next: (action: any) => void,
@@ -61,7 +66,7 @@ function createNetworkMiddleware(
 
     // We don't want to dispatch actions all the time, but rather when there is a dismissal case
     const isAnyActionToBeDismissed = find(actionQueue, (a: *) => {
-      const actionsToDismiss = get(a, 'meta.dismiss', []);
+      const actionsToDismiss = get(a, `meta${namespace || ''}.dismiss`, []);
       return actionsToDismiss.includes(action.type);
     });
     if (isAnyActionToBeDismissed && !isConnected) {

--- a/src/index.js
+++ b/src/index.js
@@ -2,6 +2,9 @@ module.exports = {
   get reducer() {
     return require('./reducer').default;
   },
+  get reducerMaker() {
+    return require('./reducer').maker
+  },
   get withNetworkConnectivity() {
     return require('./withNetworkConnectivity').default;
   },

--- a/src/types.js
+++ b/src/types.js
@@ -9,6 +9,10 @@ export type FluxAction = {
   },
 };
 
+export type ReducerConfig = {
+  namespace?: string,
+}
+
 export type FluxActionWithPreviousIntent = {
   type: string,
   payload: {


### PR DESCRIPTION
This provides an API to prevent collisions with other inhabitants of the meta namespace.

Sorry in advance if this does not pass your tests - I had difficulty building due to dependency problems, but I did my best to make sure everything is as clean as possible.
