### PR TITLE
Add option to define react-native-offline reducer path

### DIFF
--- a/README.md
+++ b/README.md
@@ -75,6 +75,7 @@ type Config = {
   pingServerUrl?: string = 'https://google.com',
   withExtraHeadRequest?: boolean = true,
   checkConnectionInterval?: number = 0,
+  selector?: Function = (state) => state.network
 }
 ```
 
@@ -88,6 +89,8 @@ type Config = {
 `withExtraHeadRequest`: flag that denotes whether the extra ping check will be performed or not. Defaults to `true`.
 
 `checkConnectionInterval`: the interval (in ms) you want to ping the server at. The default is 0, and that means it is not going to regularly check connectivity.
+
+`selector`: location of react native offline reducer. Default location is 'network'.
 
 ##### Usage
 ```js
@@ -228,7 +231,8 @@ createNetworkMiddleware(config: Config): ReduxMiddleware
 
 type Config = {
   regexActionType?: RegExp = /FETCH.*REQUEST/,
-  actionTypes?: Array<string> = []
+  actionTypes?: Array<string> = [],
+  selector?: Function = (state) => state.network
 }
 ```
 
@@ -239,6 +243,8 @@ This is the setup you need to put in place for libraries such as `redux-saga` or
 By default it's configured to intercept actions for fetching data following the Redux [convention](http://redux.js.org/docs/advanced/AsyncActions.html). That means that it will intercept actions with types such as `FETCH_USER_ID_REQUEST`, `FETCH_PRODUCTS_REQUEST` etc.
 
 `actionTypes`: array with additional action types to intercept that don't fulfil the RegExp criteria. For instance, it's useful for actions that carry along refreshing data, such as `REFRESH_LIST`.
+
+`selector`: location of react native offline reducer. Default location is 'network'.
 
 ##### Thunks Config
 For `redux-thunk` library, the async flow is wrapped inside functions that will be lazily evaluated when dispatched, so our store is able to dispatch functions as well. Therefore, the configuration differs:

--- a/src/createNetworkMiddleware.js
+++ b/src/createNetworkMiddleware.js
@@ -20,10 +20,11 @@ type State = {
 type Arguments = {|
   regexActionType: RegExp,
   actionTypes: Array<string>,
+  selector: Function
 |};
 
 function createNetworkMiddleware(
-  { regexActionType = /FETCH.*REQUEST/, actionTypes = [] }: Arguments = {},
+  { regexActionType = /FETCH.*REQUEST/, actionTypes = [], selector = state => state.network }: Arguments = {},
 ) {
   return ({ getState }: MiddlewareAPI<State>) => (
     next: (action: any) => void,
@@ -34,7 +35,7 @@ function createNetworkMiddleware(
     if ({}.toString.call(actionTypes) !== '[object Array]')
       throw new Error('You should pass an array as actionTypes param');
 
-    const { isConnected, actionQueue } = getState().network;
+    const { isConnected, actionQueue } = selector(getState())
 
     const isObjectAndMatchCondition =
       typeof action === 'object' &&

--- a/src/withNetworkConnectivity.js
+++ b/src/withNetworkConnectivity.js
@@ -18,6 +18,7 @@ type Arguments = {
   pingServerUrl?: string,
   withExtraHeadRequest?: boolean,
   checkConnectionInterval?: number,
+  selector: Function
 };
 
 type State = {
@@ -31,6 +32,7 @@ const withNetworkConnectivity = (
     pingServerUrl = 'https://google.com',
     withExtraHeadRequest = true,
     checkConnectionInterval = 0,
+    selector = state => state.network
   }: Arguments = {},
 ) => (WrappedComponent: ReactClass<*>) => {
   if (typeof withRedux !== 'boolean') {
@@ -118,7 +120,7 @@ const withNetworkConnectivity = (
         typeof store.dispatch === 'function' &&
         withRedux === true
       ) {
-        const actionQueue = store.getState().network.actionQueue;
+        const actionQueue = selector(store.getState()).actionQueue
 
         if (isConnected !== store.getState().network.isConnected) {
           store.dispatch(connectionChange(isConnected));

--- a/src/withNetworkConnectivity.js
+++ b/src/withNetworkConnectivity.js
@@ -122,7 +122,7 @@ const withNetworkConnectivity = (
       ) {
         const actionQueue = selector(store.getState()).actionQueue
 
-        if (isConnected !== store.getState().network.isConnected) {
+        if (isConnected !== selector(store.getState()).isConnected) {
           store.dispatch(connectionChange(isConnected));
         }
         // dispatching queued actions in order of arrival (if we have any)


### PR DESCRIPTION
Currently  react-native-offline reducer  by default have global path 'network'.
With this change users could add additional selector function which will point to custom reducer path.

For example reducer could be part of some global network reducer or could just use some other name than 'network'.