### PR TITLE
update connection type event (in the readme)

### DIFF
--- a/README.md
+++ b/README.md
@@ -414,13 +414,13 @@ function isNetworkConnected(): Promise<boolean> {
     return new Promise(resolve => {
       const handleFirstConnectivityChangeIOS = isConnected => {
         NetInfo.isConnected.removeEventListener( // Cleaning up after initial detection
-          'change',
+          'connectionChange',
           handleFirstConnectivityChangeIOS,
         );
         resolve(isConnected);
       };
       NetInfo.isConnected.addEventListener(
-        'change',
+        'connectionChange',
         handleFirstConnectivityChangeIOS,
       );
     });


### PR DESCRIPTION
[Starting React-Native v0.48.4 the NetInfo's "change" event is deprecated](https://github.com/facebook/react-native/releases/tag/v0.48.4)

The new event type is 'connectionChange'