### PR TITLE
Fixes issue where `actionQueue` was not dispatching actions on network reconnect

### DIFF
--- a/src/sagas.js
+++ b/src/sagas.js
@@ -123,7 +123,7 @@ function* handleConnectivityChange(
   hasInternetAccess: boolean,
 ): Generator<*, *, *> {
   yield put(connectionChange(hasInternetAccess));
-  const actionQueue = select(
+  const actionQueue = yield select(
     (state: { network: NetworkState }) => state.network.actionQueue,
   );
 


### PR DESCRIPTION
#72 

Add yield in front of select call in handleConnectivityChange function